### PR TITLE
Making Grorg Heroku-deployable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-*.sqlite3
+venv
+*.pyc
+staticfiles

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn grorg.wsgi --log-file -

--- a/README
+++ b/README
@@ -1,4 +1,0 @@
-Grorg
------
-
-A semi-experimental platform for managing grant applications.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Grorg
+
+A semi-experimental platform for managing grant applications.
+
+## Deploying on Heroku
+
+Click the button below to automatically set up the Grorg in an app
+running on your Heroku account.
+
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/honzajavorek/grorg)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+    "name": "Grorg",
+    "description": "A semi-experimental platform for managing grant applications.",
+    "repository": "https://github.com/andrewgodwin/grorg",
+    "website": "https://github.com/andrewgodwin/grorg",
+    "keywords": [
+        "python",
+        "django"
+    ],
+    "addons": [
+        "heroku-postgresql:hobby-dev"
+    ],
+    "scripts": {
+        "postdeploy": "python manage.py migrate"
+    }
+}

--- a/grorg/settings.py
+++ b/grorg/settings.py
@@ -9,8 +9,9 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+
 import os
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 SECRET_KEY = "secret"
 
@@ -58,11 +59,9 @@ AUTH_USER_MODEL = 'users.User'
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 
+import dj_database_url
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
+    'default': dj_database_url.config()
 }
 
 # Internationalization
@@ -78,15 +77,20 @@ USE_L10N = True
 
 USE_TZ = True
 
-
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 
+STATIC_ROOT = 'staticfiles'
 STATIC_URL = '/static/'
 
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, "static"),
+    os.path.join(BASE_DIR, 'static'),
 )
+
+# Heroku
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+ALLOWED_HOSTS = ['*']
 
 # Import local settings if present
 try:

--- a/grorg/wsgi.py
+++ b/grorg/wsgi.py
@@ -11,4 +11,6 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "grorg.settings")
 
 from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
+from dj_static import Cling
+
+application = Cling(get_wsgi_application())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django>=1.7
+django-toolbelt>=0.0.1


### PR DESCRIPTION
Hi,

this is not a real Pull Request, it's more an issue for discussion. I made it as Pull Request so diff of my changes is visible.

In [Django Girls tutorial](http://organize.djangogirls.org/attendees/README.html#how-to-choose-attendees) I learned this app should help me with scoring applications. However, Grorg has no documentation on how to set it up and how to work with it. I tried to make it Heroku-deployable (using [Creating a 'Deploy to Heroku' Button](https://devcenter.heroku.com/articles/heroku-button) and [Getting Started with Django on Heroku](https://devcenter.heroku.com/articles/getting-started-with-django) tutorials) and I sort of succeeded:

![screen shot 2015-04-29 at 23 46 21](https://cloud.githubusercontent.com/assets/283441/7402157/fef538ac-eec9-11e4-9931-623dd2d51241.png)

However, when opening the app, I see only missing `index.html`:

![screen shot 2015-04-29 at 23 49 49](https://cloud.githubusercontent.com/assets/283441/7402229/7c056d9e-eeca-11e4-9dd3-c419251eaa0d.png)

Live: https://grorg.herokuapp.com/

As there are no further docs than code and I haven't had time to dig into the app itself to try to imagine what should be there and how could I fix it, I am shamelessly asking for help to get it running. Any suggestions? I am willing to make contributions for README, tutorial, Heroku-button, etc. in the future to make Grorg more friendly, but now I need it up and running for Django Girls in Prague.