### PR TITLE
Update CSV reader logic to work with Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.sqlite3
+__pycache__

--- a/grants/migrations/0001_initial.py
+++ b/grants/migrations/0001_initial.py
@@ -64,7 +64,7 @@ class Migration(migrations.Migration):
             name='Question',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('type', models.CharField(max_length=50, choices=[(b'boolean', b'Yes/No'), (b'text', b'Text'), (b'integer', b'Integer value')])),
+                ('type', models.CharField(max_length=50, choices=[('boolean', 'Yes/No'), ('text', 'Text'), ('integer', 'Integer value')])),
                 ('question', models.TextField()),
                 ('order', models.IntegerField(default=0)),
                 ('program', models.ForeignKey(to='grants.Program', to_field='id', on_delete=models.CASCADE)),
@@ -84,7 +84,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=100)),
-                ('type', models.CharField(max_length=50, choices=[(b'money', b'Money'), (b'ticket', b'Ticket'), (b'place', b'Place'), (b'accomodation', b'Accomodation')])),
+                ('type', models.CharField(max_length=50, choices=[('money', 'Money'), ('ticket', 'Ticket'), ('place', 'Place'), ('accomodation', 'Accomodation')])),
                 ('program', models.ForeignKey(to='grants.Program', to_field='id', on_delete=models.CASCADE)),
             ],
             options={

--- a/grants/migrations/0004_auto_20140624_0435.py
+++ b/grants/migrations/0004_auto_20140624_0435.py
@@ -14,10 +14,10 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='question',
             name='type',
-            field=models.CharField(max_length=50, choices=[(b'boolean', b'Yes/No'), (b'text', b'Short text'), (b'textarea', b'Long text'), (b'integer', b'Integer value')]),
+            field=models.CharField(max_length=50, choices=[('boolean', 'Yes/No'), ('text', 'Short text'), ('textarea', 'Long text'), ('integer', 'Integer value')]),
         ),
         migrations.AlterUniqueTogether(
             name='applicant',
-            unique_together=set([(b'program', b'email')]),
+            unique_together=set([('program', 'email')]),
         ),
     ]

--- a/grants/migrations/0005_auto_20140624_1719.py
+++ b/grants/migrations/0005_auto_20140624_1719.py
@@ -29,10 +29,10 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='score',
-            unique_together=set([(b'applicant', b'user')]),
+            unique_together=set([('applicant', 'user')]),
         ),
         migrations.AlterUniqueTogether(
             name='answer',
-            unique_together=set([(b'applicant', b'question')]),
+            unique_together=set([('applicant', 'question')]),
         ),
     ]

--- a/grants/migrations/0006_auto_20140625_0139.py
+++ b/grants/migrations/0006_auto_20140625_0139.py
@@ -27,11 +27,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='score',
             name='comment',
-            field=models.TextField(help_text=b'Seen only by other voters, not by the applicant', null=True, blank=True),
+            field=models.TextField(help_text='Seen only by other voters, not by the applicant', null=True, blank=True),
         ),
         migrations.AlterField(
             model_name='score',
             name='score',
-            field=models.FloatField(help_text=b'From 0 (terrible) to 5 (excellent)', null=True, blank=True),
+            field=models.FloatField(help_text='From 0 (terrible) to 5 (excellent)', null=True, blank=True),
         ),
     ]

--- a/grants/migrations/0007_auto_20140625_0314.py
+++ b/grants/migrations/0007_auto_20140625_0314.py
@@ -25,6 +25,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='allocation',
-            unique_together=set([(b'applicant', b'resource')]),
+            unique_together=set([('applicant', 'resource')]),
         ),
     ]

--- a/grants/migrations/0010_auto_20150320_1734.py
+++ b/grants/migrations/0010_auto_20150320_1734.py
@@ -69,7 +69,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='score',
             name='score',
-            field=models.FloatField(help_text=b'From 1 (terrible) to 5 (excellent)', null=True, blank=True),
+            field=models.FloatField(help_text='From 1 (terrible) to 5 (excellent)', null=True, blank=True),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/grants/models.py
+++ b/grants/models.py
@@ -23,7 +23,7 @@ class Program(models.Model):
 
     users = models.ManyToManyField("users.User", blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     class urls(Urls):
@@ -64,7 +64,7 @@ class Resource(models.Model):
     class urls(Urls):
         edit = "{self.program.urls.resources}{self.id}/"
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def fa_icon(self):
@@ -103,7 +103,7 @@ class Question(models.Model):
     class urls(Urls):
         edit = "{self.program.urls.questions}{self.id}/"
 
-    def __unicode__(self):
+    def __str__(self):
         return self.question
 
     def can_delete(self):
@@ -125,7 +125,7 @@ class Applicant(models.Model):
         view = "{self.program.urls.applicants}{self.id}/"
         allocations = "{view}allocations/"
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def average_score(self):

--- a/grants/views/bulk_load.py
+++ b/grants/views/bulk_load.py
@@ -27,7 +27,7 @@ class BulkLoader(ProgramMixin):
         else:
             csv_obj = UploadedCSV.objects.get(pk=request.POST["csv_id"])
         # We always get a CSV file - parse it.
-        reader = csv.reader([x + "\n" for x in str(csv_obj.csv).split("\n")])
+        reader = csv.reader([x + "\n" for x in csv_obj.csv.decode().split("\n")])
         rows = list(reader)
         headers = rows[0]
         column_choices = [("", "---")] + list(enumerate(headers))

--- a/users/models.py
+++ b/users/models.py
@@ -52,5 +52,5 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         send_mail(subject, message, from_email, [self.email], **kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name or self.email


### PR DESCRIPTION
I think Heroku forcibly upgraded grorg to Python 3, which broke CSV loading.

Because the type of the `csv_obj.csv` field will be a `bytes`, we need to decode that into a utf-8 `str` before passing it into
`csv.reader()`. This avoids the headers being parsed incorrectly, such as the first field being named `b'My Field`.

This also fixes migrations to work with Python 3 and replaces `__unicode__` with `__str__`

CSV parsing works now!
![image](https://user-images.githubusercontent.com/7773256/173377910-3a1c06a6-2a26-4493-98a8-33b80d6be631.png)
